### PR TITLE
Do not export getRegistryAndName and use docker-toolbelt instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Do not export getRegistryAndName and use docker-toolbelt instead
+
 # v2.3.0
 
 * Updated to bluebird 3
@@ -6,6 +8,7 @@
 
 # v2.2.0
 
+* Support pulling from registry v2
 * Correctly handle progress during concurrent push.
 * Added linting.
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.0.0",
+    "docker-toolbelt": "^1.2.0",
     "dockerode": "^2.2.3",
     "humanize": "0.0.9",
     "lodash": "^4.0.0",


### PR DESCRIPTION
As it is now, if we get an image name in the form of `user/repo:tag` the regex will match `user` as the registry, which will in turn cause the request to `#{registry}/v2` to fail.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/docker-progress/11)

<!-- Reviewable:end -->
