### PR TITLE
Fix use of `_.sum` for lodash 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fix use of `_.sum` for lodash 4
 * Do not export getRegistryAndName and use docker-toolbelt instead
 
 # v2.3.0

--- a/index.coffee
+++ b/index.coffee
@@ -224,7 +224,7 @@ exports.DockerProgress = class DockerProgress
 		@getLayerDownloadSizes(image)
 		.spread (layerSizes, remoteLayerIds) ->
 			layerIds = {} # map from remote to local ids
-			totalSize = _.sum(layerSizes)
+			totalSize = _.sum(_.values(layerSizes))
 			completedSize = 0
 			currentDownloadedSize = {}
 			return (evt) ->
@@ -247,7 +247,7 @@ exports.DockerProgress = class DockerProgress
 						completedSize = totalSize
 						currentDownloadedSize = {}
 
-					downloadedSize = completedSize + _.sum(currentDownloadedSize)
+					downloadedSize = completedSize + _.sum(_.values(currentDownloadedSize))
 					percentage = calculatePercentage(downloadedSize, totalSize)
 
 					onProgress(_.merge(evt, { downloadedSize, totalSize, percentage }))
@@ -262,7 +262,7 @@ exports.DockerProgress = class DockerProgress
 			layerIds = _.keys(layerSizes)
 			layerPushedSize = {}
 			completedSize = 0
-			totalSize = _.sum(layerSizes)
+			totalSize = _.sum(_.values(layerSizes))
 			return (evt) ->
 				try
 					{ status } = evt
@@ -278,7 +278,7 @@ exports.DockerProgress = class DockerProgress
 						if longId?
 							completedSize += layerSizes[longId]
 							layerPushedSize[longId] = 0
-					pushedSize = completedSize + _.sum(layerPushedSize)
+					pushedSize = completedSize + _.sum(_.values(layerPushedSize))
 					percentage = calculatePercentage(pushedSize, totalSize)
 					onProgress(_.merge(evt, { pushedSize, totalSize, percentage }))
 				catch err


### PR DESCRIPTION
In lodash 4 `_.sum` only works for  arrays, so we need to extract the values of object properties.
This bug shows as totalSize being calculated as 0, and therefor percentage being shown as 100.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/docker-progress/15)

<!-- Reviewable:end -->
