### PR TITLE
Updated to docker-toolbelt 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Updated to docker-toolbelt 1.3.1
+
 # v2.3.1
 
 * Fix use of `_.sum` for lodash 4

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.0.0",
-    "docker-toolbelt": "^1.2.0",
+    "docker-toolbelt": "^1.3.1",
     "dockerode": "^2.2.3",
     "humanize": "0.0.9",
     "lodash": "^4.0.0",


### PR DESCRIPTION
Fixes an issue where a user of the exported Docker object would fail with `run` due to the multiple callback arguments not being passed on the fulfilled Promise.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/docker-progress/16)
<!-- Reviewable:end -->
