### PR TITLE
Fixed getting registry version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed getting registry version
+
 # v2.4.2
 
 * Restore public-facing APIs that were incorrectly removed in v2.4.0

--- a/legacy.coffee
+++ b/legacy.coffee
@@ -183,7 +183,7 @@ exports.ProgressReporter = class ProgressReporter
 		.then ({ registry, imageName, tagName }) ->
 			registry.getLayerDownloadSizes(imageName, tagName)
 			.spread (layerSizes, remoteLayerIds) ->
-				[ registry.getVersion(), layerSizes, remoteLayerIds ]
+				[ registry.version, layerSizes, remoteLayerIds ]
 
 	# Create a stream that transforms `docker.modem.followProgress` onProgress
 	# events to include total progress metrics.


### PR DESCRIPTION
Pull progress from registry v1 with Docker<1.10 is broken due to this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-io/docker-progress/20)
<!-- Reviewable:end -->
