### PR TITLE
Add support for building images with progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@balena/lint": "^5.4.1",
-    "@types/dockerode": "^3.2.3",
+    "@types/dockerode": "^3.3.3",
     "rimraf": "^3.0.2",
     "typescript": "^4.2.4"
   },


### PR DESCRIPTION
Using build instead of pull allows to add label metadata to pulled images in an
atomic way. This commit adds the `DockerProgress.build()` method to
build an image from a remote (or local) source.

Change-type: minor