### PR TITLE
Propagate NodeJS Error from stream directly

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -84,13 +84,13 @@ async function awaitRegistryStream(
 		jsonStream.on('error', reject);
 		jsonStream.on('close', reject);
 		jsonStream.on('end', () => resolve(contentHash));
-		jsonStream.on('data', (evt: any) => {
+		jsonStream.on('data', (evt) => {
 			if (typeof evt !== 'object') {
 				return;
 			}
 			try {
 				if (evt.error && !ignoreErrorEvents) {
-					throw new Error(evt.error);
+					throw evt.error instanceof Error ? evt.error : new Error(evt.error);
 				}
 				// try to extract the digest before forwarding the object
 				const maybeContent = tryExtractDigestHash(evt);
@@ -704,7 +704,8 @@ export class DockerProgress {
 		if (options?.authconfig) {
 			const { serveraddress, ...authconfig } = options.authconfig;
 			options.registryconfig = {
-				[serveraddress]: authconfig,
+				...(serveraddress &&
+					({ [serveraddress]: authconfig } as RegistryConfig)),
 
 				// Override with registryconfig if it the same serveraddress
 				// is used in both options


### PR DESCRIPTION
If the error throw from registry stream is already a Node Error, wrapping it in an error again may obfuscate additional properties of the Node error. This commit passes the error directly if it's already an Error instance.

Change-type: patch