### PR TITLE
Support `abortSignal` option for image push/pull

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -36,6 +36,7 @@ export interface PullPushOptions {
 		auth?: string;
 		registrytoken?: string;
 	};
+	abortSignal: AbortSignal;
 }
 
 export interface BuildOptions extends ImageBuildOptions {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "rimraf": "^6.0.0",
     "typescript": "^5.3.3"
   },
+  "peerDependencies": {
+    "dockerode": ">=3.3.1",
+    "docker-modem": ">=3.0.3"
+  },
   "versionist": {
     "publishedAt": "2025-04-10T13:59:53.990Z"
   }


### PR DESCRIPTION
Allows `abortSignal` as an option for image pulls & pushes, passing it to the `options` param of dockerode's pull/push.

Dockerode supports AbortSignal as of [v3.3.1](https://github.com/apocas/dockerode/releases/tag/v3.3.1), and docker-modem as of [v3.0.3](https://github.com/apocas/docker-modem/commit/cd6e76b4cdeddab689e4546c20da8fef9174991a)

Change-type: minor
