### PR TITLE
pull: fix digest hash parsing

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -67,7 +67,9 @@ function tryExtractDigestHash(evt: {
 		return evt.aux.Digest;
 	}
 	if (typeof evt.status === 'string') {
-		const matchPull = evt.status.match(/^Digest:\s([a-zA-Z0-9]+:[a-f0-9]+)$/);
+		const matchPull = evt.status.match(
+			/[Dd]igest:\s([a-zA-Z0-9]+:[a-f0-9]+)[\s$]/,
+		);
 		return matchPull?.[1];
 	}
 }


### PR DESCRIPTION
The current code assumes the digest status line is in the form `Digest: <alg>:<hash>`, taking up the whole line. This is not at all the case on all docker daemon versions, which is now in the form `<tag>: digest: <alg>:<hash> size: <size>`.

Fix the regex to accept both formats:

- accept leading characters before the digest part
- make the `d` case-insensitive
- accept trailing elements after the hash

Without this fix, `balena deploy` is broken both with Balena Cloud and Open Balena. It's a problem for the latter as it's the only deploy means using it.

Note: I don't really know when the format changed, or what are the setup details for it. However, this is the observed format for both Docker 28.5.2 on Arch Linux and Docker 26.1.5 on Debian 13, both from the repos.