### PR TITLE
awaitRegistryStream: Handle error events on source stream

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": ["ts-node/register"],
+  "spec": "test/**/*.spec.ts",
+  "timeout": 5000
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -194,6 +194,7 @@ async function awaitRegistryStream(
 			}
 		});
 
+		stream.on('error', reject);
 		stream.pipe(jsonStream);
 	});
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "npm run clean && npm run lint && tsc",
     "lint": "balena-lint lib",
     "lint-fix": "balena-lint --fix lib",
-    "test": "npm run lint && npm run build",
+    "test": "npm run lint && npm run build && TS_NODE_PROJECT=tsconfig.test.json mocha",
     "prepack": "npm run build"
   },
   "license": "Apache-2.0",
@@ -31,14 +31,19 @@
   },
   "devDependencies": {
     "@balena/lint": "^9.2.2",
+    "@types/chai": "^5.2.3",
     "@types/JSONStream": "npm:@types/jsonstream@^0.8.33",
     "@types/lodash": "^4.14.202",
+    "@types/mocha": "^10.0.10",
+    "chai": "^6.2.2",
+    "mocha": "^11.7.5",
     "rimraf": "^6.0.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "dockerode": ">=3.3.1",
-    "docker-modem": ">=3.0.3"
+    "docker-modem": ">=3.0.3",
+    "dockerode": ">=3.3.1"
   },
   "versionist": {
     "publishedAt": "2025-12-03T19:06:39.744Z"

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,0 +1,78 @@
+import { PassThrough } from 'node:stream';
+import { expect } from 'chai';
+
+import { DockerProgress } from '../lib/index';
+
+describe('awaitRegistryStream', () => {
+	it('pull() rejects when the Docker response stream emits an error', async () => {
+		const sourceStream = new PassThrough();
+
+		const mockDocker = {
+			version: async () => ({ Version: '20.10.0' }),
+			pull: async () => sourceStream,
+		};
+
+		const dp = new DockerProgress({ docker: mockDocker as any });
+
+		setTimeout(() => {
+			sourceStream.destroy(new Error('socket hang up'));
+		}, 50);
+
+		try {
+			await dp.pull('test-image', () => {});
+			expect.fail('Expected promise to reject');
+		} catch (err: any) {
+			expect(err).to.be.an.instanceOf(Error);
+			expect(err.message).to.equal('socket hang up');
+		}
+	});
+
+	it('push() rejects when the Docker response stream emits an error', async () => {
+		const sourceStream = new PassThrough();
+
+		const mockDocker = {
+			version: async () => ({ Version: '20.10.0' }),
+			getImage: () => ({
+				push: async () => sourceStream,
+			}),
+		};
+
+		const dp = new DockerProgress({ docker: mockDocker as any });
+
+		setTimeout(() => {
+			sourceStream.destroy(new Error('read ECONNRESET'));
+		}, 50);
+
+		try {
+			await dp.push('test-image', () => {});
+			expect.fail('Expected promise to reject');
+		} catch (err: any) {
+			expect(err).to.be.an.instanceOf(Error);
+			expect(err.message).to.equal('read ECONNRESET');
+		}
+	});
+
+	it('build() rejects when the Docker response stream emits an error', async () => {
+		const sourceStream = new PassThrough();
+		const tarStream = new PassThrough();
+
+		const mockDocker = {
+			version: async () => ({ Version: '20.10.0' }),
+			buildImage: async () => sourceStream,
+		};
+
+		const dp = new DockerProgress({ docker: mockDocker as any });
+
+		setTimeout(() => {
+			sourceStream.destroy(new Error('context canceled'));
+		}, 50);
+
+		try {
+			await dp.build(tarStream, () => {});
+			expect.fail('Expected promise to reject');
+		} catch (err: any) {
+			expect(err).to.be.an.instanceOf(Error);
+			expect(err.message).to.equal('context canceled');
+		}
+	});
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["lib/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Node's .pipe() does not propagate errors from source to destination. If the Docker response stream errors, such as with network drop, socket hangup, context cancellation, etc., the error is emitted only on source stream. Without a listener there, this either crashes the process or, if another listener swallows it, leaves the promise hanging indefinitely.

Add stream.on('error', reject) so source stream errors properly reject the promise.

Also add tests.

TODO: Instead of `stream.pipe`, we should use a more modern solution like Node's [pipeline](https://nodejs.org/api/stream.html#streampipelinestreams-options)

Change-type: patch